### PR TITLE
make the gitrob licence agreement path to work with given version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ruby
 LABEL maintainer "@awhitehatter"
 
+ENV GITROB_VERSION 1.1.2
+
 # Install required packages
 RUN apt-get update && apt-get install -y build-essential libpq-dev \
-    && gem update --system && gem install gitrob
+    && gem update --system && gem install gitrob -v $GITROB_VERSION
 
 # There's an error with the newest Ruby github_api Gem - Heh Ruby; Workaround:
 RUN gem uninstall --force github_api && gem install github_api -v 0.13
@@ -12,7 +14,7 @@ RUN gem uninstall --force github_api && gem install github_api -v 0.13
 ADD ./data/.gitrobrc /root/.gitrobrc
 
 #ASSUMING YOU ARE ACCEPTING THE MIT LICENSE
-RUN echo "user accepted" > /usr/local/bundle/gems/gitrob-1.1.0/agreement.txt
+RUN echo "user accepted" > ls /usr/local/bundle/gems/gitrob-$GITROB_VERSION/agreement.txt
 
 ENTRYPOINT ["/usr/local/bundle/bin/gitrob"]
 


### PR DESCRIPTION
When I attempted to run this it failed as the licence agreement path was hardcoded to `1.1.0` version while the latest has moved to `1.1.2`.

This PR makes the gitrob version explicit as an environment variable.